### PR TITLE
Blobstore reroute of form input

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentServlet.java
@@ -1,0 +1,80 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.servlets;
+
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import java.io.IOException;
+import com.google.gson.Gson;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.ArrayList;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * When user submits the form, Blobstore processes the image upload and then forwards the request
+ * to this servlet. This servlet processes the request using the file URL we get from Blobstore.
+ */
+@WebServlet("/comments")
+public class CommentServlet extends HttpServlet {
+
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Query query = new Query("siteComments").addSort("timeSubmitted", SortDirection.DESCENDING);
+        PreparedQuery results = datastore.prepare(query);
+
+        List<String> allComments = new ArrayList<>();
+        List<String> allImageURLs = new ArrayList<>();
+
+        int numCommentsWanted = 0;
+        boolean desiredNumCommentsFound = false;
+        for (Entity entity : results.asIterable()) {
+            String comment = (String) (entity.getProperty("comment"));
+            allComments.add(comment);
+            String imageURL = (String) (entity.getProperty("imageURL"));
+            allImageURLs.add(imageURL);
+
+            // Grab number of comments wanted to be seen by user only in the first entity
+            if (!desiredNumCommentsFound) {
+                numCommentsWanted = Integer.parseInt((String)(entity.getProperty("numCommentsWanted")));
+                desiredNumCommentsFound = true;
+            }   
+        }
+
+        if (numCommentsWanted > allComments.size()) {
+            numCommentsWanted = allComments.size();           
+        }
+
+        // Chop out comments beyond the number of comments wanted
+        allComments = allComments.subList(0, numCommentsWanted);
+        allImageURLs = allImageURLs.subList(0, numCommentsWanted);
+        
+        List<String> commentsAndImageURLs = new ArrayList<>();
+        commentsAndImageURLs.addAll(allComments);
+        commentsAndImageURLs.addAll(allImageURLs);
+
+        response.setContentType("application/json;");
+        Gson gson = new Gson();
+        response.getWriter().println(gson.toJson(commentsAndImageURLs));
+
+    }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -20,10 +20,7 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.gson.Gson;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -36,8 +33,9 @@ public final class DeleteDataServlet extends HttpServlet {
     /** Delete data in Datastore and redirect to index.html */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        System.out.println("INSIDE delete POST");
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-        Query query = new Query("siteComments").addSort("timeStamp", SortDirection.DESCENDING);
+        Query query = new Query("siteComments").addSort("timeSubmitted", SortDirection.DESCENDING);
         PreparedQuery results = datastore.prepare(query);
 
         for (Entity entity : results.asIterable()) {

--- a/portfolio/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -22,6 +22,13 @@ import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.appengine.api.images.ImagesService;
 import com.google.appengine.api.images.ImagesServiceFactory;
 import com.google.appengine.api.images.ServingUrlOptions;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import java.io.IOException;
 import com.google.gson.Gson;
 import java.io.PrintWriter;
@@ -36,86 +43,87 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * When user submits the form, Blobstore processes the image upload and then forwards the request
- * to this servlet. This servlet processes the request using the file URL we get from Blobstore.
+ * When user submits the form, Blobstore processes the image upload along with other input and then forwards the request
+ * to this servlet. This servlet processes the request and stores it in Datastore.
  */
 @WebServlet("/my-form-handler")
 public class FormHandlerServlet extends HttpServlet {
 
-  /** Handles form input of commment, number of comments, and an image converted to JSON to put on servlet. */
-  @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        
-        // COMMENTING REASON: Former Datastore implementation of comments form, saving as reference for step 2 of new Blobstore implementation:
+    /** Processes and stores into Datastore: commment, number of comments, and an image. */
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        long timestamp = System.currentTimeMillis();
+
+        // Get form input redirected through Blobstore.
+        String newComment = getParameter(request, "text-input", ""); 
+        String numCommentsString = getParameter(request, "num-comments", "0");
+
+        // Get URL of image that the user uploaded to Blobstore.
+        String imageLink = getUploadedFileUrl(request, "image");
 
 
-        // DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-        // Query query = new Query("siteComments").addSort("timeStamp", SortDirection.DESCENDING);
-        // PreparedQuery results = datastore.prepare(query);
- 
-        // List<String> pastComments = new ArrayList<>();
- 
-        // int numCommentsWanted = 0;
-        // boolean desiredNumCommentsFound = false;
-        // for (Entity entity : results.asIterable()) {
-        //     String comment = (String) (entity.getProperty("newComment"));
-        //     pastComments.add(comment);
+        // Make new Datastore entity to submit to storage
+        Entity commentEntity = new Entity("siteComments");
+        commentEntity.setProperty("timeSubmitted", timestamp);
+        commentEntity.setProperty("comment", newComment);
+        commentEntity.setProperty("numCommentsWanted", numCommentsString);
+        commentEntity.setProperty("imageURL", imageLink);
 
-        //     // Grab number of comments wanted to be seen by user only in the first entity
-        //     if (!desiredNumCommentsFound) {
-        //         numCommentsWanted = Integer.parseInt((String)(entity.getProperty("seeNumComments")));
-        //         desiredNumCommentsFound = true;
-        //     }   
-        // }
- 
-        // if (numCommentsWanted > pastComments.size()) {
-        //     numCommentsWanted = pastComments.size();           
-        // }
- 
-        // pastComments = pastComments.subList(0, numCommentsWanted);
- 
-        // response.setContentType("application/json;");
-        // Gson gson = new Gson();
-        // response.getWriter().println(gson.toJson(pastComments));
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        datastore.put(commentEntity);
 
-  }
+        response.sendRedirect("/index.jsp");
+    }
 
+    /** Returns a URL that points to the uploaded file, or null if the user didn't upload a file. */
+    private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
+        BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+        Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+        List<BlobKey> blobKeys = blobs.get("image");
+
+        // User submitted form without selecting a file, so can't get a URL. (dev server)
+        if (blobKeys == null || blobKeys.isEmpty()) {
+            return null;
+        }
+
+        // Form only contains a single file input, so get the first index.
+        BlobKey blobKey = blobKeys.get(0);
+
+        // User submitted form without selecting a file, so can't get a URL. (live server)
+        BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+        if (blobInfo.getSize() == 0) {
+            blobstoreService.delete(blobKey);
+            return null;
+        }
+
+        // We could check the validity of the file here, e.g. to make sure it's an image file
+        // https://stackoverflow.com/q/10779564/873165
+
+        // Use ImagesService to get a URL that points to the uploaded file.
+        ImagesService imagesService = ImagesServiceFactory.getImagesService();
+        ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
+
+        // To support running in Google Cloud Shell with AppEngine's devserver, we must use the relative
+        // path to the image, rather than the path returned by imagesService which contains a host.
+        try {
+            URL url = new URL(imagesService.getServingUrl(options));
+            return url.getPath();
+        } catch (MalformedURLException e) {
+            return imagesService.getServingUrl(options);
+        }
+    } 
+
+    /** Gets one value of the form input. 
+    * Note that number of comments wanted input will be none or >= 0 due to HTML form restriction.
+    * No input converts to default (ex: No number input is handled as 0 comments wanted.)
+    * @return request parameter or default value if parameter was not specified by client */
+    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null) {
+            System.out.println("No input received for " + name + ".");
+            return defaultValue;
+        }
+        return value;
+    }
+    
 }
-
-
- 
-    // COMMENTING REASON: Former Datastore implementation of comments form, saving as reference for step 2 of new Blobstore implementation:
-
-
-    // /** Process POST request form input, add to pastComments, and redirect to index.html */
-    // @Override
-    // public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    //     long timestamp = System.currentTimeMillis();
-        
-    //     // Get the input from the form.
-    //     String comment = getParameter(request, "text-input", ""); 
-    //     String numCommentsString = getParameter(request, "num-comments", "0");
-
-    //     Entity commentEntity = new Entity("siteComments");
-    //     commentEntity.setProperty("timeStamp", timestamp);
-    //     commentEntity.setProperty("newComment", comment);
-    //     commentEntity.setProperty("seeNumComments", numCommentsString);
-
-    //     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    //     datastore.put(commentEntity);
-
-    //     response.sendRedirect("/index.html");
-    // }
- 
-    // /** Gets certain name (type) form input. 
-    // * No form input converts to default (ex: No number input is handled as 0 comments wanted.)
-    // * Number input will be none or >= 0 due to HTML form restrictions.
-    // * @return request parameter or default value if parameter was not specified by client */
-    // private String getParameter(HttpServletRequest request, String name, String defaultValue) {
-    //     String value = request.getParameter(name);
-    //     if (value == null) {
-    //         System.out.println("No input received for " + name + ".");
-    //         return defaultValue;
-    //     }
-    //     return value;
-    // }

--- a/portfolio/src/main/java/com/google/sps/servlets/FunFactServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/FunFactServlet.java
@@ -23,8 +23,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
  
 /** Servlet that prints fun facts. */
-@WebServlet("/data")
-public final class DataServlet extends HttpServlet {
+@WebServlet("/funfacts")
+public final class FunFactServlet extends HttpServlet {
  
     List<String> funFacts = new ArrayList<>();
     

--- a/portfolio/src/main/webapp/index.jsp
+++ b/portfolio/src/main/webapp/index.jsp
@@ -29,7 +29,7 @@ limitations under the License.
         <script src="script.js"></script>
     </head>
  
-    <body onload="fetchFactsComments(0)">
+    <body onload="getComments()">
  
     <div id="content">
         <div class="text-container">
@@ -83,7 +83,6 @@ limitations under the License.
         <br>
         <form method="POST" action="<%= uploadUrl %>" enctype="multipart/form-data">
             
-            <p>Here is the uploadUrl created by Blobstore: <%= uploadUrl %></p>
             <p>Post a Site Comment with a Corresponding Image:</p>
             <textarea name="text-input">Write comment here</textarea>
             <p>Upload an image:</p>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -42,17 +42,37 @@ function getFunFact() {
  
 /** Builds Unordered List of site comment history */
 function getComments() {
-    const historyUL = document.getElementById('commentHistory');
-    siteComments.forEach((line) => {
-        historyUL.appendChild(createListElement(line));
+    fetch('/comments').then(response => response.json()).then((allCommentsImages) => {       
+        var halfLength = allCommentsImages.length / 2;
+
+        var comments = allCommentsImages.slice(0, halfLength);
+        var imageURLS = allCommentsImages.slice(halfLength)
+        
+        const historyUL = document.getElementById('commentHistory');
+
+        var index = 0;
+        comments.forEach((comment) => {
+            historyUL.appendChild(createListElement(comment, imageURLS[index]));
+            index++;
+        });
     });
 }
  
-/** Creates an <li> list item element containing text. */
-function createListElement(text) {
-  const liElement = document.createElement('li');
-  liElement.innerText = text;
-  return liElement;
+/** Creates an <img> list item element containing image. */
+function createListElement(text, url) {
+    console.log("Comment is: " + text + " and url is: " + url);
+    const liElement = document.createElement('li');
+    liElement.innerText = text;
+
+    var attribute1 = document.createAttribute("style");
+    attribute1.value = "list-style-image: url('" + url + "')";
+
+    var attribute2 = document.createAttribute("style");
+    attribute2.value = "text-align: center";
+
+    liElement.setAttributeNode(attribute1);
+    liElement.setAttributeNode(attribute2); 
+    return liElement;
 }
 
 /** Removes any current li elements on the page and fetches DeleteDataServlet to rid Datastore data. */
@@ -64,7 +84,7 @@ async function deleteComments() {
         list.removeChild(list.firstChild);
     }
     let response = await fetch('/delete-data', {method: 'POST'});
-    fetchFactsComments(0);
+    getComments();
 }
   
 


### PR DESCRIPTION
Blobstore takes in form input, making a URL for every image input.
Form servlet retrieves the Blobstore transformed form input to store in DataStore and proceed as before to show wanted number of comments.

Images showing on screen is happening, but placed to far to the left. Will fix first thing Monday.